### PR TITLE
fix `GaiaClass.cone_search_async()` for astroquery>=0.4.7

### DIFF
--- a/docs/installation.ipynb
+++ b/docs/installation.ipynb
@@ -68,7 +68,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.13"
   },
   "orig_nbformat": 4
  },

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: thefriendlystars
 site_url: https://zkbt.github.com/thefriendlystars
 nav:
     - Welcome: index.md
+    - installation.ipynb
     - gaia.ipynb
 theme:
   name: "material"

--- a/setup.py
+++ b/setup.py
@@ -86,10 +86,10 @@ setup(
         "astropy",
         "jupyter",
         "tqdm",
-        "astroquery"
+        "astroquery>=0.4.7"
     ],
     # what version of Python is required?
-    python_requires=">=3.7",  # f-strings are introduced in 3.6!
+    python_requires=">=3.8",  # f-strings are introduced in 3.6!
     # requirements in `key` will install with `pip install thefriendlystars[key]`
     extras_require={
         "develop": [

--- a/thefriendlystars/gaia.py
+++ b/thefriendlystars/gaia.py
@@ -123,7 +123,7 @@ def get_gaia(center, radius=6 * u.arcmin):
     # get the data from the archive
     job = Gaia.cone_search_async(
         center_skycoord,
-        radius,
+        radius=radius,
         columns=[
             "source_id",
             "ra",
@@ -167,6 +167,7 @@ def plot_gaia(
     faintest_magnitude_to_label=16,
     size_of_zero_magnitude=100,
     unit=u.arcmin,
+    **kwargs
 ):
     """
     Plot a finder chart using results from `get_gaia_data`.
@@ -193,6 +194,8 @@ def plot_gaia(
         Default is 100.
     unit : Unit
         What unit should be used for labels? Default is u.arcmin.
+    **kwargs : dict 
+        Additional keywords will be passed to `plt.scatter`.
     """
 
     # extract the center and size of the field
@@ -214,7 +217,7 @@ def plot_gaia(
     with quantity_support():
 
         # plot the stars
-        plt.scatter(dra, ddec, s=marker_size, color="black")
+        plt.scatter(dra, ddec, s=marker_size, **kwargs)
         plt.xlabel(
             rf"$\Delta$(Right Ascension) [{unit}] relative to {center.ra.to_string(u.hour, format='latex', precision=2)}"
         )

--- a/thefriendlystars/version.py
+++ b/thefriendlystars/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 
 def version():


### PR DESCRIPTION
@Autumn10677 found a bug, where the way we were calling the `astroquery` Gaia cone search didn't work with the updated 0.4.7 version. This fixes that, and updates the dependencies and version number.