### PR TITLE
add some developer instructions to docs

### DIFF
--- a/docs/documentation.ipynb
+++ b/docs/documentation.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0c858c15",
+   "metadata": {},
+   "source": [
+    "# Writing Documentation\n",
+    "\n",
+    "If you're contributing a new feature to `thefriendlystars`, please consider also contributing some documentation to explain how your feature works. Here's the very short version of how to add to the documentation:\n",
+    "\n",
+    "1. Install in development mode (see [Installation](../installation)), so you have access to `mkdocs` and the various extensions needed to render the documentation.\n",
+    "1. Decide whether your explanation would fit well within an existing page or whether you need a new one. In the `docs/` directory, find the appropriate `.ipynb` notebook file or create a new one. If you create a new one, add it to the `nav:` section of the `mkdocs.yml` file in the main repository directory so that `mkdocs` will know to include it.\n",
+    "1. Write your example and explanation in a `.ipynb` file. Your audience should be smart people who want to use the code but don't have much experience with it yet. Be friendly and encouraging!\n",
+    "1. From the Terminal, run `mkdocs serve`. This will convert all of the source notebooks into a live website, and give you a little address that you can copy and paste into a browser window. While that `mkdocs serve` command is still running, small changes you make to existing `.ipynb` source files will appear (sometimes after a few minutes) on the live locally-hosted webserver. \n",
+    "1. Once you're happy with your new documentation, before committing it to the repository, please run \"Kernal > Restart & Clear Output\" or something similar to remove all outputs from the source notebook file. The `thefriendlystars` repository will hang onto *all* changes that you commit to it, so it would very quickly get annoyingly large unless we leave the outputs out of committed notebook files. Double check the outputs are all gone, save your notebook, and then commit it to the `git` repository (see [Contributing Code with GitHub](../github)).\n",
+    "\n",
+    "Periodically, after reviewing and copy-editing the documentation, we'll deploy the newest version up to the web at [zkbt.github.io/thefriendlystars/](https://zkbt.github.io/thefriendlystars/) for all to enjoy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0842b4c9",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/github.ipynb
+++ b/docs/github.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1c9b17bb",
+   "metadata": {},
+   "source": [
+    "# Contributing Code with GitHub\n",
+    "\n",
+    "There are oodles of great tutorials on various aspects of contributing to collaborative code projects with GitHub. This page is meant to provide a quick, recipe-like answer to the question \"how do I contribute to the `thefriendlystars` package?\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6edf4f26",
+   "metadata": {},
+   "source": [
+    "## Should I submit an Issue to the `thefriendlystars` GitHub repository? \n",
+    "\n",
+    "Yes! You tried out `thefriendlystars` and maybe thought it had some neat features, but you encountered something that didn't work quite how you expected it to, a question that you couldn't find an answer to in the documentation, or a feature that you wished existed. Those would all be great motivations to go to the `thefriendlystars` GitHub repository to [submit an Issue](https://github.com/zkbt/thefriendlystars/issues)!\n",
+    "\n",
+    "But...we know you! You're saying to yourself \"Oh, gosh, they have their hands full, I don't want to bother them right now. I'm sure I'm the only one having this problem or with this question about how `thefriendlystars` works. My idea probably matters only to me and not anyone else. I don't want to make more work for other folks.\" You're wringing your hands and anxiously worrying about about whether to [submit an Issue](https://github.com/zkbt/thefriendlystars/issues).\n",
+    "\n",
+    "Still, can we please encourage you share your problem, ask your question, or make your suggestion? Your experience and curiosity and creativity would be extremely valuable contributions to the package, and make it better for everyone. It's super exciting to hear that someone new else trying to use this code package, and every bit of discussion about how to improve it is super helpful. I promise we're very friendly! So, please, hop on over and [submit an Issue](https://github.com/zkbt/thefriendlystars/issues)!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f91bc20b",
+   "metadata": {},
+   "source": [
+    "## How do we get started with `git` and GitHub?\n",
+    "\n",
+    "Yay! You're interested in contributing some code to the `thefriendlystars` package. The first step will be to make sure you have a basic familiarity with `git` and GitHub as tools for safe and collaborative coding. \n",
+    "\n",
+    "Christina Hedges has written some great resources on [coding-related workflows for astronomy](https://christinahedges.github.io/astronomy_workflow/), including a tutorial for getting started with `git` and GitHub that you can [watch here](https://exoplanet-talks.org/talk/366). If you're entirely new to these tools, please work through her tutorial and then come back here. If you haven't created one yet, make yourself a GitHub account "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c261ad84",
+   "metadata": {},
+   "source": [
+    "## How do we contribute new code? \n",
+    "\n",
+    "Because we have more than one person working on `thefriendlystars` code, let's please use separate `git` [branches](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches) for developing new features. Using branches allows us to write code in parallel and merge it together later, without constantly having to make sure that everything everybody writes is up-to-date everywhere all at once. We're generally trying to follow something like the [Gitflow Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow), to allow us to make changes to the shared code that are a little bit buffered from the published code used by non-developers. \n",
+    "\n",
+    "There three branches you should know about, and only two you should probably interact with:\n",
+    "- The `main` branch hosts the published version of the code for public users. New `pip` versions of the code will be released from the `main` branch. Most developers will rarely interact directly with the `main` branch.\n",
+    "- The `develop` branch is the active branch for shared development. New feature branches should be created from the `develop` branch and once they're reviewed be merged back into `develop`. Occasionally, and only after careful testing and documentation edits, the `develop` branch will get merged into the `main` branch and published to `pip`. \n",
+    "- Your `add-amazing-awesome-new-feature` branch (where you replace the name with something more specific and informative) is a temporary branch that you created off of `develop` to add your amazing awesome new feature. You should make your changes and commits to that branch, and when you're ready to discuss to your contribution (either as a draft or a mostly finished product), you should submit a Pull Request from this feature branch into the `develop` branch. Features should be tested well enough that they won't break `develop` when they get merged into it (but if they do, possibly due to a temporary conflict with another feature branch, it's OK because the `main` branch is still safe). Once it's merged, your feature branch will be deleted, and you can start a new one to add a different new feature.\n",
+    "\n",
+    "With these branches, here's what writing some new code for `thefriendlystars` might look like for you. The following describes using `git` from the Terminal prompt. In practice, you might interact with `git` mostly through [Visual Studio Code](https://code.visualstudio.com/), [PyCharm](https://www.jetbrains.com/pycharm/), [GitHub Desktop](https://desktop.github.com/), or some other tool.\n",
+    "1. Discuss your plans in an [Issue](https://github.com/zkbt/thefriendlystars/issues). You might start from trying to address an existing issue, or you might add a new issue of your own. Either way, it's really helpful to let other folks know \"here's what I'm trying to do\" to avoid duplicate or unfocused efforts. If you're not already a Collaborator on the `thefriendlystars` repository, we can add you at this point!\n",
+    "1. Use the [Installation](../installation) instructions to complete the Developer Installation. This will download the `develop` branch of the `thefriendlystars` repository onto your computer and set up your environment to point to the repository's directory. \n",
+    "```\n",
+    "git clone https://github.com/zkbt/thefriendlystars.git\n",
+    "cd thefriendlystars\n",
+    "pip install -e '.[develop]'\n",
+    "```\n",
+    "1. Create a new feature branch off of `develop`. Check out that branch, so that all commits you make will be associated with that branch.\n",
+    "```\n",
+    "git checkout develop\n",
+    "git branch add-amazing-awesome-new-feature\n",
+    "git checkout add-amazing-awesome-new-feature\n",
+    "```\n",
+    "1. Write your code. Ideally you should also please some useful tests, but it's OK for us to iterate on those as more of a conversaion. Once you've saved some changes to the code, commit those changes to your feature branch. (You can confirm you're on your feature branch by running `git branch` and seeing which branch has the `*`.)\n",
+    "```\n",
+    "git add .\n",
+    "git commit -m \"{include informative commit message here}\"\n",
+    "```\n",
+    "Up to this point, whatever changes you have committed are still only stored on your computer.\n",
+    "1. To start sharing your new code, push your branch up to GitHub. The first time you run this push command, you'll probably get some instructions about how to link your local branch to a new remote one that you're about to create; follow them.\n",
+    "```\n",
+    "git push\n",
+    "```\n",
+    "Now your branch and most recently pushed commits should appear in the GitHub [list of branches](https://github.com/zkbt/thefriendlystars/branches). \n",
+    "1. To ask for your code to be reviewed, either because you think it's finished or because you've completed enough of a draft to be useful to start discussing, submit a [Pull Request](https://github.com/zkbt/thefriendlystars/pulls) asking us to pull the code from your feature branch into `develop`. We'll probably discuss a few aspects of it and suggest some changes, which can be implemented by continuing to push new commits to your feature branch as long as the Pull Request is still open. Once it's tested and works and we're all happy with it, we'll merge the code into `develop`, from where it will eventually then be merged into the `main` branch and released in the latest `pip` version.\n",
+    "1. 🌈🎉🤩 Celebrate! "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32151e81",
+   "metadata": {},
+   "source": [
+    "## What kinds of files should we commit? \n",
+    "\n",
+    "Every file change commit to the repository will be stored and able to be recovered in the future. That's great for being able to go back to previous versions in the code's history, but it means that the repository could very easily get very big if we include lots of large files in our commits. Large files are extra troublesome if they change frequently, because then we're storing a new copy of every large file in our repository. \n",
+    "\n",
+    "Let's try to keep the `thefriendlystars` repository relatively slim. To do that, please:\n",
+    "- Avoid committing large data, image, or movie files to the repository. If you think you need to include a large file (anything over ~1 MB), raise an Issue to discuss your plans. There might be a better alternative.\n",
+    "- Avoid committing scratch jupyter notebook files where you're testing out new code. The only notebooks that should be committed to `thefriendlystars` are ones meant to serve as public documentation; those should be stored in the `docs/` folder as described in [Writing Documentation](../documentation) and their outputs should be cleared before saving."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9402d05b",
+   "metadata": {},
+   "source": [
+    "## Wait, I have a question that's not answered here!\n",
+    "\n",
+    "This page is a whirlwind tour! We probably missed lots of important information. If you have a question, no matter how small or large or seemingly basic, please ask Zach or [submit an Issue](https://github.com/zkbt/thefriendlystars/issues)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/installation.ipynb
+++ b/docs/installation.ipynb
@@ -1,8 +1,8 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
+   "id": "843b76f4",
    "metadata": {},
    "source": [
     "# Installation\n",
@@ -10,6 +10,8 @@
     "For installing this code we assume you have a Python environment set up, into which you can install packages via `pip`. If so, please continue to one of the installation options below.\n",
     "\n",
     "If this isn't the case, we recommend installing the [Anaconda Python distribution](https://www.anaconda.com/products/distribution), and using `conda` to manage the `python` environment(s) you have installed on your computer. One tutorial (of many) about how to get started with Python and creating `conda` environments is available [here](https://github.com/ers-transit/hackathon-2021-day0).\n",
+    "\n",
+    "*In these instructions, you might notice we use `thefriendlystars` for installing this package or working with its GitHub repository but `thefriendlystars` whenever we actually import it into Python. *\n",
     "\n",
     "## Basic Installation\n",
     "\n",
@@ -25,9 +27,47 @@
     "```\n",
     "to download any officially released updates.\n",
     "\n",
+    "## Basic Installation in New `conda` Environment\n",
+    "\n",
+    "If you are at all worried about the installation messing up other existing packages on your computer or if you're having trouble getting a tricky dependency to install, please consider installing into a new `conda` environment. Environments are independent of each other, so what you install into one shouldn't affect others.\n",
+    "\n",
+    "From the Terminal or Anaconda Prompt, please run\n",
+    "```\n",
+    "conda create -n my-neato-thefriendlystars-environment python=3.12\n",
+    "```\n",
+    "to create a new, empty environment centered on a recent-ish version of `python`. You may want to choose a shorter name for your neato environment, as it's something you'll need to type every time you want to use this environment. Run\n",
+    "```\n",
+    "conda activate my-neato-thefriendlystars-environment\n",
+    "```\n",
+    "to enter than environment. You can check that you're in it by running \n",
+    "```\n",
+    "conda env list\n",
+    "```\n",
+    "and looking for a little star next to the environment name. Now, from within this environment, run\n",
+    "```\n",
+    "pip install --upgrade thefriendlystars\n",
+    "```\n",
+    "to install `thefriendlystars` and all its dependencies (or follow the Developer Installation instructions immediately below), into this specific environment. \n",
+    "\n",
+    "One thing to watch out for is that if you haven't installed whatever tools you use to work with `python` (such as `jupyter` or `spyder`) into this environment, you might not be able to open them or you might open them from your base environment without access to this package. To fix that, run\n",
+    "```\n",
+    "conda install jupyter spyder\n",
+    "```\n",
+    "from inside your environment. From now on, whenever you want to use this environment, activate it with\n",
+    "```\n",
+    "conda activate my-neato-thefriendlystars-environment\n",
+    "```\n",
+    "and then open your `python` interface from within that environment, as with any one of these\n",
+    "```\n",
+    "jupyter notebook \n",
+    "jupyter lab\n",
+    "spyder \n",
+    "```\n",
+    "Good luck!\n",
+    "\n",
     "## Developer Installation\n",
     "\n",
-    "If you want to install this code while being able to edit and develop it, you can clone its [GitHub repository](https://github.com/zkbt/thefriendlystars.git) onto your own computer. This allows you to edit it for your own sake and/or to draft changes that can be contributed to the public package (after being added as a collaborator to the project on GitHub).\n",
+    "If you want to install this code while being able to edit and develop it, you can clone its [GitHub repository](https://github.com/zkbt/thefriendlystars.git) onto your own computer. This allows you to edit it for your own sake and/or to draft changes that can be contributed to the public package (see [Contributing 🌈 Code with GitHub](../github)).\n",
     "\n",
     "To install directly as an editable package on your local computer, run\n",
     "```\n",
@@ -44,17 +84,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f1dbd472",
    "metadata": {},
    "outputs": [],
    "source": [
     "import thefriendlystars\n",
+    "\n",
     "thefriendlystars.version()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "238ab3e2",
+   "metadata": {},
+   "source": [
+    "Happy `exoplanet-atlas`-ing!"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "chromatic",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -68,10 +118,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
-  },
-  "orig_nbformat": 4
+   "version": "3.8.5"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/docs/testing.ipynb
+++ b/docs/testing.ipynb
@@ -1,0 +1,67 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Testing Code Automatically"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we write more and more code, especially bits that start to depend on each other in complicated ways, its easy for bugs and unexpected behavior to creep in. Or, as versions of various dependencies get updated from year to year, some code that used to behave one way might stop working.\n",
+    "\n",
+    "To help solve these problems, we can write simple tests for our code. When we make changes to the code package, we can run the tests to make sure we haven't broken anything and the code's doing what we want. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "source": [
+    "## How do we test code with `pytest`? \n",
+    "Here's a quick overview of what running tests might look like:\n",
+    "\n",
+    "1. Write a snippet of code that should work if your code is working and (ideally) raise an error if not. \n",
+    "2. Put that code in a function that has the string `test` in its name, stored in a `.py` file with `test` in its name inside the `thefriendlystars/tests` directory. \n",
+    "3. From the main repository directory, from the command line run `pytest`. This will search for all your test functions, run them all, and give you a report about what worked and what didn't. (The [Developer Installation](../installation/#developer-installation) should have automatically installed `pytest` for you.)\n",
+    "\n",
+    "If one or more of your tests break, you either need to fix something in your code or in your test function. If all of your tests pass, your should celebrate and feel very pleased with yourself. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "source": [
+    "## What are useful tests?\n",
+    "\n",
+    "The most useful tests are the ones you've actually written! It's OK if your automatic tests don't comprehensively cover every single possible way that your code might goof up; often a code's error might be a fundamental conceptual misunderstanding that can only be caught by a clever and cautious human noticing something amiss in a plot. \n",
+    "\n",
+    "In approximate order from simpler to more sophisticated, tests might look like:\n",
+    "- Does this function run on reasonable inputs? \n",
+    "- Does it run, and give plausible outputs? \n",
+    "- Does it run, give accurate outputs? \n",
+    "- Does it run, give accurate outputs, and respond appropriately to changing inputs? \n",
+    "- Does it run, give accurate outputs, respond appropriately, and raise informative errors when it should? \n",
+    "\n",
+    "No matter how detailed and thoughtfully you write your tests, the Universe is complicated, so they might not capture every fascinating way your code might break. Don't aim for perfection; just try to do something."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,12 @@ site_url: https://zkbt.github.com/thefriendlystars
 nav:
     - Welcome: index.md
     - installation.ipynb
-    - gaia.ipynb
+    - User Guide:
+      - gaia.ipynb
+    - Developer Guide:
+      - github.ipynb
+      - testing.ipynb
+      - documentation.ipynb
 theme:
   name: "material"
   features:
@@ -32,7 +37,6 @@ plugins:
             show_if_no_docstring: False
             heading_level: 3
             show_bases: False
-      custom_templates: templates
   - exclude:
       glob:
         - "*.pdf"


### PR DESCRIPTION
This copies over and finds-and-replaces my standard developer instructions into the docs. These were copied from `exoatlas`, which in turn came from `chromatic`. The main topics covered (so far):
- Contributing Code with GitHub
- Testing Code Automatically
- Writing Documentation

